### PR TITLE
added a 'g' to 'loggin_in' to correspond with the # relocation in the help page

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -15,7 +15,7 @@
   <li><%= link_to "Authoring", "help/authoring"%></li>
 </ol>
 
-<div class="sectionHeading" id="loggin_in">Logging In</div>
+<div class="sectionHeading" id="logging_in">Logging In</div>
 
 <p>Registering for an account and logging in to Quadbase is easy. Follow the steps below to register and log in to the site.</p>
 


### PR DESCRIPTION
Someone forgot to add the g :p. Should be self-explanatory from the code diffs. Found it while doing some work with the dialog boxes.
