### PR TITLE
Copy solutions when deriving questions. Fix icons for voting on solutions

### DIFF
--- a/app/assets/stylesheets/quadbase.css.scss
+++ b/app/assets/stylesheets/quadbase.css.scss
@@ -479,6 +479,11 @@ a:active {
 	filter: progid:DXImageTransform.Microsoft.Shadow(Strength=4, Direction=135, Color='#000000');
 }
 
+.votes_td {
+  vertical-align: middle;
+  padding-left: 5px;
+}
+
 /************ GENERIC LIST TABLE *********************/
 
 table.list {

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -312,7 +312,9 @@ class QuestionsController < ApplicationController
     
     begin
       @question = @source_question.new_derivation!(present_user, project)
-      flash[:notice] = "Derived question created."
+      flash[:notice] = "Derived question created.
+                        Please make sure to edit the solutions page before publishing,
+                        as you will be unable to remove others' solutions afterwards."
       respond_to do |format|
         if edit_now
           format.html { redirect_to edit_question_path(@question) }

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -21,7 +21,7 @@ class Solution < ActiveRecord::Base
   attr_accessible :content, :explanation, :is_visible
   
   scope :visible_for, lambda { |user|
-    where{(creator_id == user.id) | (is_visible == true)}
+    joins{question}.where{(creator_id == user.id) | (is_visible == true) | (question.version == nil)}
   }
   
   before_save :auto_subscribe
@@ -42,13 +42,22 @@ class Solution < ActiveRecord::Base
   def auto_subscribe
     comment_thread.subscribe!(creator) if creator.user_profile.auto_author_subscribe
   end
+  
+  def content_copy
+    kopy = Solution.new
+    kopy.creator = self.creator
+    kopy.content = self.content
+    kopy.explanation = self.explanation
+    kopy.is_visible = self.is_visible
+    kopy
+  end
     
   #############################################################################
   # Access control methods
   #############################################################################
 
   def can_be_read_by?(user)
-    user.can_read?(question) && (is_visible || (!user.is_anonymous? && user == creator))
+    user.can_read?(question) && (is_visible || (!user.is_anonymous? && user == creator) || !question.is_published?)
   end
 
   def can_be_created_by?(user)
@@ -60,7 +69,8 @@ class Solution < ActiveRecord::Base
   end
 
   def can_be_destroyed_by?(user)
-    !user.is_anonymous? && (user == creator || user.is_administrator?)
+    !user.is_anonymous? && (user == creator || user.is_administrator? ||
+      (!question.is_published? && user.can_read?(question)))
   end
 
   def can_be_voted_on_by?(user)

--- a/app/views/shared/_votes.html.erb
+++ b/app/views/shared/_votes.html.erb
@@ -18,11 +18,11 @@
         <%= image_tag("thumbs_up_hover.png") %>
         <% else %>
         <%= image_submit_tag "thumbs_up.png",
-              :onmouseover => "this.src='/images/thumbs_up_hover.png'",
-              :onmouseout => "this.src='/images/thumbs_up.png'" %><br />
+              :onmouseover => "this.src='/assets/thumbs_up_hover.png'",
+              :onmouseout => "this.src='/assets/thumbs_up.png'" %><br />
         <% end %>
       </td>
-      <td>
+      <td class="votes_td">
         <%= label_tag votable.votes.where{thumbs_up == true}.count %>
       </td>
     </tr>
@@ -38,11 +38,11 @@
         <%= image_tag "thumbs_down_hover.png" %>
         <% else %>
         <%= image_submit_tag "thumbs_down.png",
-              :onmouseover => "this.src='/images/thumbs_down_hover.png'",
-              :onmouseout => "this.src='/images/thumbs_down.png'" %><br />
+              :onmouseover => "this.src='/assets/thumbs_down_hover.png'",
+              :onmouseout => "this.src='/assets/thumbs_down.png'" %><br />
         <% end %>
       </td>
-      <td>
+      <td class="votes_td">
         <%= label_tag votable.votes.where{thumbs_up == false}.count %>
       </td>
     </tr>

--- a/app/views/solutions/_single_solution.html.erb
+++ b/app/views/solutions/_single_solution.html.erb
@@ -34,7 +34,7 @@
                       :remote => !destroy_not_remote) %>
     <% end %>
     </span>
-    <br/>
+    <br clear="all">
 
     <span style="float:right">
     <%= render :partial => 'shared/votes',
@@ -42,39 +42,6 @@
     </span>
 
  </div>
- 
- <% if false %>
- <span class="comment_actions">
-
-   <% if show_link %>
-     <%= link_to show_icon, solution_path(solution), :class => "show_link" %>
-   <% end %>
-
-   <% if present_user.can_update?(solution) %>
-     <%= link_to edit_icon, edit_solution_path(solution), :class => "edit_link" %>
-   <% end %>&nbsp;
-
-   <% if present_user.can_destroy?(solution) %>
-     <%= link_to(trash_icon, 
-                     solution, 
-                     :confirm => 'Are you sure you want to delete this solution?', 
-                     :method => :delete,
-                     :id => "delete_solution_#{solution.id.to_s}",
-                     :class => "delete_link",
-                     :remote => !destroy_not_remote) %>
-   <% end %>
-
- </span>
-
-
- <br/>
- 
- <span style="float:right">
- <%= render :partial => 'shared/votes',
-            :locals => {:votable => solution} %>
- </span>
- 
- <% end %>
 
  <div class="solution_div" style="float:left; width:85%">
    <% if !solution.explanation.blank? %>


### PR DESCRIPTION
Here's how I've done this:

When deriving a copy of a question, it will copy all (visible) solutions by you and everyone who is a question collaborator.

These solutions will still be marked as visible. You cannot edit them, but you can remove them if you want.
