### PR TITLE
Added new rake task to generate question export json file

### DIFF
--- a/app/views/questions/_attribution.jsonify
+++ b/app/views/questions/_attribution.jsonify
@@ -1,20 +1,32 @@
 # Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
 # License version 3 or later.  See the COPYRIGHT file for details.
 
+@export ||= false
+
 collaborators = question.question_collaborators
 
 authors = collaborators.select{|c| c.is_author}
 copyright_holders = collaborators.select{|c| c.is_copyright_holder}
 
+def print_user(json, user)
+  json.id user.id
+  json.name user.full_name
+
+  if @export
+    json.first_name user.first_name
+    json.last_name user.last_name
+    json.username user.username
+    json.email user.email
+  end
+end
+
 json.attribution do
   json.authors(authors) do |author|
-    json.id author.user.id
-    json.name author.user.full_name
+    print_user(json, author.user)
   end
 
   json.copyright_holders(copyright_holders) do |copyright_holder|
-    json.id copyright_holder.user.id
-    json.name copyright_holder.user.full_name
+    print_user(json, copyright_holder.user)
   end
 
   json.license do

--- a/app/views/questions/_common.jsonify
+++ b/app/views/questions/_common.jsonify
@@ -1,5 +1,9 @@
 # Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
 # License version 3 or later.  See the COPYRIGHT file for details.
 
+@export ||= false
+
 json.id question.to_param
-json.url question_url(question)
+unless @export
+  json.url question_url(question)
+end

--- a/lib/tasks/export_questions.rake
+++ b/lib/tasks/export_questions.rake
@@ -1,0 +1,16 @@
+# Copyright 2014 Rice University. Licensed under the Affero General Public 
+# License version 3 or later.  See the COPYRIGHT file for details.
+
+# http://stackoverflow.com/a/2624395
+namespace :questions do
+  task :export, [:filename] => :environment do |t, args|
+    filename = args[:filename] || 'questions.json'
+    puts 'Exporting questions. Please wait...'
+    output = ApplicationController.new.render_to_string(
+               :template => 'questions/search',
+               :locals => {:@questions => Question.all,
+                           :@export => true},
+               :formats => [:jsonify])
+    File.open(filename, 'w') { |file| file.write(output) }
+  end
+end


### PR DESCRIPTION
`rake questions:export` will create `questions.json`
Includes all questions, even drafts
Includes user names, usernames and email addresses (no password hash)
